### PR TITLE
Fix result list not to have null value

### DIFF
--- a/src/main/java/io/github/eb4j/stardict/DictionaryData.java
+++ b/src/main/java/io/github/eb4j/stardict/DictionaryData.java
@@ -89,7 +89,9 @@ class DictionaryData<T> {
         }
         if (value instanceof Object[]) {
             for (Object o : (Object[]) value) {
-                into.add(new AbstractMap.SimpleImmutableEntry<>(key, (T) o));
+                if (o != null) {
+                    into.add(new AbstractMap.SimpleImmutableEntry<>(key, (T) o));
+                }
             }
         } else {
             into.add(new AbstractMap.SimpleImmutableEntry<>(key, (T) value));


### PR DESCRIPTION
- Result list can have null value that can lead NPE. This fix avoid null value from result list.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>