### PR TITLE
Update cache expiry policy from afterWrite to afterAccess

### DIFF
--- a/src/main/java/io/github/eb4j/stardict/StarDictDictionary.java
+++ b/src/main/java/io/github/eb4j/stardict/StarDictDictionary.java
@@ -57,7 +57,7 @@ public abstract class StarDictDictionary implements AutoCloseable {
         this.info = info;
         cache = Caffeine.newBuilder()
                 .maximumSize(maxsize)
-                .expireAfterWrite(duration)
+                .expireAfterAccess(duration)
                 .build(e -> readArticle(e.getStart(), e.getLen()));
     }
 


### PR DESCRIPTION
- Current cache policy is based on write, but it should expiry with last recent read
- This change policy to `afterAccess`